### PR TITLE
+ GH actions: release workflow bugfix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Publish package to JSR
-        run: deno publish
+        run: npx jsr publish


### PR DESCRIPTION
- use  `npx jsr` instead of `deno`